### PR TITLE
Add inverseHandler to Load decorator and related services

### DIFF
--- a/src/decorators/load/load.decorator.spec.ts
+++ b/src/decorators/load/load.decorator.spec.ts
@@ -389,4 +389,34 @@ describe("Load Decorator", () => {
 			child: TeamMember,
 		});
 	});
+
+	it("should add valid inverseHandler relationship metadata to LazyMetadataContainer", () => {
+		class Photo {
+			id: number;
+			userId: number;
+		}
+
+		class User {
+			id: number;
+
+			@Load(() => Photo, { key: "id", parentKey: "userId", handler: "LOAD_PHOTOS_BY_USER_IDS", inverseHandler: "LOAD_USERS_BY_PHOTO_IDS" })
+			photo: Photo;
+		}
+
+		LazyMetadataContainer.loadRelationshipMetadata();
+
+		const userRelations = LazyMetadataContainer.loadedRelationships.get(User);
+		expect(userRelations).toBeDefined();
+
+		const photoMetadata = userRelations?.get("photo");
+		expect(photoMetadata).toMatchObject({
+			key: "id",
+			parentKey: "userId",
+			handler: "LOAD_PHOTOS_BY_USER_IDS",
+			inverseHandler: "LOAD_USERS_BY_PHOTO_IDS",
+			type: RelationType.OneToOne,
+			parent: User,
+			child: Photo,
+		});
+	});
 });

--- a/src/decorators/load/load.decorator.ts
+++ b/src/decorators/load/load.decorator.ts
@@ -7,10 +7,11 @@ interface LoadOptions<Child, Parent> {
 	key: Paths<Parent>;
 	parentKey: Paths<Child>;
 	handler: string;
+	inverseHandler?: string;
 }
 
 export function Load<Child, Parent = any>(child: ChildFN<Child>, options: LoadOptions<Child, Parent>) {
-	const { key, parentKey, handler } = options;
+	const { key, parentKey, handler, inverseHandler } = options;
 	return (target: NonNullable<any>, propertyKey: string) => {
 		const parent = () => target.constructor as Type;
 
@@ -18,6 +19,7 @@ export function Load<Child, Parent = any>(child: ChildFN<Child>, options: LoadOp
 			key: key as string,
 			parentKey: parentKey as string,
 			handler: handler,
+			inverseHandler: inverseHandler,
 			parentFN: parent,
 			explicitChildFN: child,
 			originalFieldName: propertyKey,

--- a/src/module/dataloader-service/dataloader.service.spec.ts
+++ b/src/module/dataloader-service/dataloader.service.spec.ts
@@ -23,6 +23,7 @@ describe("DataloaderService", () => {
 					provide: ExplorerService,
 					useValue: {
 						findMetadataHandlerByName: vi.fn(),
+						findInverseMetadataHandlerByName: vi.fn(),
 					},
 				},
 			],
@@ -872,6 +873,98 @@ describe("DataloaderService", () => {
 				expect(order.customerId).toBe(customer.id);
 				expect(order).toBeInstanceOf(Order);
 			}
+		}
+	});
+
+	it("should load inverse relationships", async () => {
+		const handlerName = "LOAD_PHOTOS_BY_USER_ID";
+		const inverseHandlerName = "LOAD_USERS_BY_PHOTO_ID";
+
+		class Photo {
+			@FactoryField((faker) => faker.number.int({ max: 99999 }))
+			id: number;
+
+			@FactoryField((faker) => faker.image.url())
+			url: string;
+
+			@FactoryField((faker) => faker.number.int({ max: 99999 }))
+			userId: number;
+
+			@Load(() => User, {
+				key: "userId",
+				parentKey: "id",
+				handler: inverseHandlerName,
+			})
+			user: User;
+		}
+
+		class User {
+			@FactoryField((faker) => faker.number.int({ max: 99999 }))
+			id: number;
+
+			@FactoryField((faker) => faker.person.fullName())
+			name: string;
+
+			@Load(() => [Photo], {
+				key: "id",
+				parentKey: "userId",
+				handler: handlerName,
+				inverseHandler: inverseHandlerName,
+			})
+			photos: Photo[];
+		}
+
+		class PhotoRepository {
+			@DataloaderHandler(handlerName)
+			static async loadByUserIds(userIds: number[]) {
+				return userIds.flatMap((userId) => {
+					return factory.createList(Photo, 3).override((photos) => {
+						for (const photo of photos) {
+							photo.userId = userId;
+						}
+						return photos;
+					});
+				});
+			}
+		}
+
+		class UserRepository {
+			@DataloaderHandler(inverseHandlerName)
+			static async loadByPhotoIds(photoIds: number[]) {
+				return photoIds.map((photoId) => factory.create(User).override(() => ({ id: photoId })));
+			}
+		}
+
+		vi.spyOn(explorerService, "findMetadataHandlerByName").mockImplementation((name) => {
+			if (name === handlerName) {
+				return {
+					repository: PhotoRepository,
+					provider: {
+						provide: PhotoRepository,
+						field: "loadByUserIds",
+					},
+				};
+			} else if (name === inverseHandlerName) {
+				return {
+					repository: UserRepository,
+					provider: {
+						provide: UserRepository,
+						field: "loadByPhotoIds",
+					},
+				};
+			}
+		});
+
+		LazyMetadataContainer.loadRelationshipMetadata();
+
+		const photos = factory.newList(Photo, 3);
+		const results = await Promise.all(
+			photos.map((photo) => dataloaderService.load({ from: Photo, field: "user", data: photo })),
+		);
+
+		expect(results).toHaveLength(3);
+		for (const [index, user] of results.entries()) {
+			expect(user.id).toBe(photos[index].userId);
 		}
 	});
 

--- a/src/module/explorer-service/explorer.service.ts
+++ b/src/module/explorer-service/explorer.service.ts
@@ -41,4 +41,25 @@ export class ExplorerService {
 			provider: provider,
 		};
 	}
+
+	findInverseMetadataHandlerByName(inverseHandlerName: string) {
+		const provider = LazyMetadataContainer.dataloaderHandlers.get(inverseHandlerName);
+
+		if (!provider) {
+			throw new Error(`cannot find provider: ${inverseHandlerName}`);
+		}
+
+		const resolvedProvider = LazyMetadataContainer.loadedAliases.get(provider.provide);
+
+		const repository = this.moduleRef.get(resolvedProvider || provider.provide, { strict: false });
+
+		if (!repository) {
+			throw new Error(`cannot find provider: ${provider.provide.name}`);
+		}
+
+		return {
+			repository: repository,
+			provider: provider,
+		};
+	}
 }

--- a/src/utils/lazy-metadata-container/lazy-metadata-container.spec.ts
+++ b/src/utils/lazy-metadata-container/lazy-metadata-container.spec.ts
@@ -463,4 +463,41 @@ describe("LazyMetadataContainer", () => {
 			expect(e.message).toBe("Dataloader handler with key findById already exists");
 		}
 	});
+
+	it("should add and load relationship metadata with inverseHandler", () => {
+		class Photo {
+			id: number;
+			userId: number;
+		}
+
+		class User {
+			id: number;
+		}
+
+		const relationship: Relationship = {
+			parentFN: () => User,
+			explicitChildFN: () => Photo,
+			key: "id",
+			parentKey: "userId",
+			handler: "findPhotosByUserId",
+			inverseHandler: "findUsersByPhotoId",
+			originalFieldName: "photos",
+		};
+
+		LazyMetadataContainer.addRelationshipMetadata(relationship);
+		LazyMetadataContainer.loadRelationshipMetadata();
+
+		const loadedRelationships = LazyMetadataContainer.loadedRelationships;
+		const userRelations = loadedRelationships.get(User);
+		const photoRelation = userRelations?.get("photos");
+
+		expect(photoRelation).toBeDefined();
+		expect(photoRelation?.type).toBe(RelationType.OneToOne);
+		expect(photoRelation?.parent).toBe(User);
+		expect(photoRelation?.child).toBe(Photo);
+		expect(photoRelation?.key).toBe("id");
+		expect(photoRelation?.parentKey).toBe("userId");
+		expect(photoRelation?.handler).toBe("findPhotosByUserId");
+		expect(photoRelation?.inverseHandler).toBe("findUsersByPhotoId");
+	});
 });

--- a/src/utils/lazy-metadata-container/lazy-metadata-container.ts
+++ b/src/utils/lazy-metadata-container/lazy-metadata-container.ts
@@ -47,6 +47,7 @@ export class LazyMetadataContainer {
 				key: unloadedRelationship.key,
 				parentKey: unloadedRelationship.parentKey,
 				handler: unloadedRelationship.handler,
+				inverseHandler: unloadedRelationship.inverseHandler,
 				type: isArray ? RelationType.OneToMany : RelationType.OneToOne,
 			};
 


### PR DESCRIPTION
Add `inverseHandler` property to `Load` decorator options and handle it in metadata and services.

* **Load Decorator**: Add `inverseHandler` to `LoadOptions` interface and include it in the metadata saved by the `Load` decorator in `src/decorators/load/load.decorator.ts`.
* **LazyMetadataContainer**: Add `inverseHandler` to the `Relationship` interface and include it in the metadata loaded by `LazyMetadataContainer` in `src/utils/lazy-metadata-container/lazy-metadata-container.ts`.
* **ExplorerService**: Add `findInverseMetadataHandlerByName` method to check for `inverseHandler` in `src/module/explorer-service/explorer.service.ts`.
* **DataloaderService**: Check for `inverseHandler` in the metadata in `extractMetadata` method and use `inverseHandler` in `getOrCreateDataloader` method if it exists in `src/module/dataloader-service/dataloader.service.ts`.
* **Tests**: Add tests for `inverseHandler` in `Load` decorator, `LazyMetadataContainer`, and `DataloaderService` in their respective spec files.

